### PR TITLE
Activate BT with button, add stop # to bluetooth config

### DIFF
--- a/src/display_handle.hpp
+++ b/src/display_handle.hpp
@@ -31,7 +31,7 @@ public:
     void WriteBanner(float battery_voltage)
     {
         char batt_str[30];
-        create_battery_string(batt_str, battery_voltage);
+        createBatteryString(batt_str, battery_voltage);
         display->print(batt_str);
         display->setCursor(150, 1);
         display->print(time_info, "%B %d %Y %H:%M");
@@ -39,7 +39,7 @@ public:
     }
 
     // Write an array of predictions to the screen
-    void write_predictions(StopPrediction predictions[], int num_predictions)
+    void writePredictions(StopPrediction predictions[], int num_predictions)
     {
         display->setTextSize(2);
         int line_number = 0;
@@ -52,12 +52,12 @@ public:
             //Serial.printf("On print object %d \n", s);
             if (arriving_in < 0) continue;
             if (line_number > 6) break;
-            write_single_prediction(pred, arriving_in);
+            writeSinglePrediction(pred, arriving_in);
            line_number++;
         }
     }
 
-    void write_bt_screen()
+    void writeBleScreen()
     {
         setCursor(2);
         display->setTextSize(2);
@@ -65,7 +65,7 @@ public:
     }
 
     // Display current data in the buffer to the screen.
-    void display_data()
+    void displayData()
     {
         display->display();
     }
@@ -77,7 +77,7 @@ public:
         //Serial.printf("set curser to y: %d \n", cursor_pos_y);
     }
 
-    void write_line(char* line)
+    void writeLine(char* line)
     {
         display->print(line);
     }
@@ -86,14 +86,14 @@ private:
     ThinkInk_290_Grayscale4_T5 *display;
     tm* time_info;
 
-    void create_battery_string(char *fill_batt, float battery_pct)
+    void createBatteryString(char *fill_batt, float battery_pct)
     {
         sprintf(fill_batt, "Batt Voltage: %2.0f %%", battery_pct);
         Serial.println();
     }
 
         // Write a prediction line at the current cursor position.
-    void write_single_prediction(StopPrediction pred, int arriving_in)
+    void writeSinglePrediction(StopPrediction pred, int arriving_in)
     {
         if (pred.hasVia())
         {

--- a/src/display_handle.hpp
+++ b/src/display_handle.hpp
@@ -57,10 +57,29 @@ public:
         }
     }
 
+    void write_bt_screen()
+    {
+        setCursor(2);
+        display->setTextSize(2);
+        display->print("Bluetooth Mode started -  Press button C to exit");
+    }
+
     // Display current data in the buffer to the screen.
     void display_data()
     {
         display->display();
+    }
+
+    void setCursor(int current_line)
+    {
+        int cursor_pos_y = 16 * (current_line + 1);
+        display->setCursor(1, cursor_pos_y);
+        //Serial.printf("set curser to y: %d \n", cursor_pos_y);
+    }
+
+    void write_line(char* line)
+    {
+        display->print(line);
     }
 
 private:
@@ -73,14 +92,7 @@ private:
         Serial.println();
     }
 
-    void setCursor(int current_line)
-    {
-        int cursor_pos_y = 16 * (current_line + 1);
-        display->setCursor(1, cursor_pos_y);
-        //Serial.printf("set curser to y: %d \n", cursor_pos_y);
-    }
-
-    // Write a prediction line at the current cursor position.
+        // Write a prediction line at the current cursor position.
     void write_single_prediction(StopPrediction pred, int arriving_in)
     {
         if (pred.hasVia())
@@ -92,4 +104,6 @@ private:
             display->printf("Bus: %s %d Min", pred.route(), arriving_in);
         }
     }
+
+
 };

--- a/src/mbta_api.hpp
+++ b/src/mbta_api.hpp
@@ -44,19 +44,19 @@ public:
 
     MbtaApi() {}
 
-    PredictionPack get_predictions(int mbta_stop_number)
+    PredictionPack getPredictions(int mbta_stop_number)
     {
-        String prediction_json = get_mbta_prediction_json(mbta_stop_number);
+        String prediction_json = getMbtaPredictionJson(mbta_stop_number);
 
-        PredictionPack predictions = parse_prediction_string(prediction_json);
+        PredictionPack predictions = parsePredictionString(prediction_json);
         return predictions;
     }
 
 private:
-    String get_mbta_prediction_json(int stop)
+    String getMbtaPredictionJson(int stop)
     {
-
-        String mbta_query_url = get_query_url(stop);
+        Serial.printf("Getting predictions for stop: %d \n", stop);
+        String mbta_query_url = getQueryUrl(stop);
        HTTPClient http;
 
         Serial.print("[HTTP] begin...\n");
@@ -67,7 +67,7 @@ private:
         String payload;
 
         // httpCode will be negative on error
-        if (http_success(httpCode))
+        if (httpSuccess(httpCode))
         {
             payload = http.getString();
         }
@@ -81,23 +81,23 @@ private:
         return payload;
     }
 
-    String get_query_url(int stop)
+    String getQueryUrl(int stop)
     {
         String mbta_query_url = "https://api-v3.mbta.com/predictions?filter[stop]=";
         mbta_query_url += stop;
         return mbta_query_url;
     }
 
-   bool http_success(int http_code)
-   {
+    bool httpSuccess(int http_code)
+    {
         // HTTP header has been send and Server response header has been handled
         Serial.printf("[HTTP] GET... code: %d\n", http_code);
         return http_code == HTTP_CODE_OK;
-   } 
+    } 
 
-    PredictionPack parse_prediction_string(String &payload)
+    PredictionPack parsePredictionString(String &payload)
     {
-        DynamicJsonDocument doc(6144);
+        DynamicJsonDocument doc(12288);
         Serial.println("allocated json");
 
         DeserializationError error = deserializeJson(doc, payload);
@@ -116,7 +116,7 @@ private:
 
         for (JsonObject elem : doc["data"].as<JsonArray>())
         {
-            prediction_pack.predictions[num_predictions] = parse_prediction_from_json(elem);
+            prediction_pack.predictions[num_predictions] = parsePredictionFromJson(elem);
 
             num_predictions++;
             Serial.printf("Adding prediction %d \n", num_predictions);
@@ -125,7 +125,7 @@ private:
         return prediction_pack;
     }
 
-    StopPrediction parse_prediction_from_json(JsonObject elem)
+    StopPrediction parsePredictionFromJson(JsonObject elem)
     {
         JsonObject attributes = elem["attributes"];
         const char *arrival_time = attributes["arrival_time"]; // "2021-03-07T09:30:51-05:00",

--- a/src/mbta_api.hpp
+++ b/src/mbta_api.hpp
@@ -57,7 +57,7 @@ private:
     {
         Serial.printf("Getting predictions for stop: %d \n", stop);
         String mbta_query_url = getQueryUrl(stop);
-       HTTPClient http;
+        HTTPClient http;
 
         Serial.print("[HTTP] begin...\n");
         http.begin(mbta_query_url, mbta_cert); //HTTP
@@ -135,6 +135,12 @@ private:
         const char *stop_id = relationships["stop"]["data"]["id"];    // "2579",
         // const char *trip_id = relationships["trip"]["data"]["id"];
         auto prediction = StopPrediction(route_num, stop_id, arrival_time);
+        addViaToRoute(prediction, route_num);
+        return prediction;
+    }
+
+    void addViaToRoute(StopPrediction &prediction, const char* route_num)
+    {
         if (strcmp(route_num, "88") == 0)
         {
             prediction.set_via("Highlnd");
@@ -143,6 +149,6 @@ private:
         {
             prediction.set_via("Elm");
         }
-        return prediction;
+ 
     }
 };

--- a/src/mbta_api.hpp
+++ b/src/mbta_api.hpp
@@ -139,6 +139,7 @@ private:
         return prediction;
     }
 
+    // Adds a "via" string to the prediction based upon the route number.
     void addViaToRoute(StopPrediction &prediction, const char* route_num)
     {
         if (strcmp(route_num, "88") == 0)

--- a/src/mbta_bluetooth.hpp
+++ b/src/mbta_bluetooth.hpp
@@ -24,7 +24,6 @@ public:
         Serial.println("writing new ssid to storage");
         auto newSSID = pCharacteristic->getValue();
         store->storeSSID(newSSID.c_str());
-        wifiChanged = true;
     }
 
 };
@@ -37,6 +36,17 @@ public:
     {
         Serial.println("writing new pass to storage");
         store->storePass(pCharacteristic->getValue().c_str());
+    }
+};
+
+class MbtaStopCallback : public wifiStoreCallback
+{
+public:
+    MbtaStopCallback(WifiCredentialStore *store) : wifiStoreCallback(store) {}
+    void onWrite(BLECharacteristic *pCharacteristic)
+    {
+        Serial.println("writing new pass to storage");
+        store->storeStop(atoi(pCharacteristic->getValue().c_str()));
     }
 };
 
@@ -55,7 +65,7 @@ public:
         auto creds = store.getCredentials();
         makeSSIDCharacteristic(creds.ssid);
         makePassCharacteristic(creds.pass);
-
+        makeStopCharacteristic(creds.mbtaStop);
     }
 
     void startServer()
@@ -107,4 +117,19 @@ private:
         pPassCharacteristic->setCallbacks(new PassCallback(&store));
 
     }
+
+    void makeStopCharacteristic(int initialStop)
+    {
+        pPassCharacteristic = pService->createCharacteristic(
+            "bebls03e-36e1-4688-b7f5-ea07361b26a8",
+            BLECharacteristic::PROPERTY_READ |
+                BLECharacteristic::PROPERTY_WRITE);
+        Serial.println("created service");
+        String stop;
+        stop.concat(initialStop);
+        pPassCharacteristic->setValue(stop.c_str());
+        pPassCharacteristic->setCallbacks(new MbtaStopCallback(&store));
+
+    }
+
 };

--- a/src/mbta_predictions.cpp
+++ b/src/mbta_predictions.cpp
@@ -160,8 +160,8 @@ void write_predictions_to_display(PredictionPack prediction_pack)
     float batt = get_battery_percentage();
     mbta_display.WriteBanner(batt);
 
-    mbta_display.write_predictions(prediction_pack.predictions, prediction_pack.num_predictions);
-    mbta_display.display_data();
+    mbta_display.writePredictions(prediction_pack.predictions, prediction_pack.num_predictions);
+    mbta_display.displayData();
 }
 
 void run_bluetooth_mode()
@@ -171,8 +171,8 @@ void run_bluetooth_mode()
     disp.PrepDisplay();
     float batt = get_battery_percentage();
     disp.WriteBanner(batt);
-    disp.write_bt_screen();
-    disp.display_data();
+    disp.writeBleScreen();
+    disp.displayData();
     delay(2000);
     testBLE();
 
@@ -192,6 +192,7 @@ void setup()
 
     auto wifistore = WifiCredentialStore();
     //wifistore.storeCredentials(networkName, networkPswd);
+    //wifistore.storeStop(2579);
 
     bool button_c = get_button_c_pressed();
     if (button_c)
@@ -209,7 +210,7 @@ void setup()
 
     MbtaApi mbta = MbtaApi();
     
-    auto prediction_pack = mbta.get_predictions(2579);
+    auto prediction_pack = mbta.getPredictions(creds.mbtaStop);
 
     write_predictions_to_display(prediction_pack);
 

--- a/src/mbta_predictions.cpp
+++ b/src/mbta_predictions.cpp
@@ -95,7 +95,7 @@ void connectToWiFi(const char *ssid, const char *pwd)
     }
 }
 
-float get_battery_percentage()
+float getBatteryPercentage()
 {
     float voltage = analogRead(A13) * 2 * (3.3 / 4096);
     float pct = map(voltage * 1000, 2900, 4000, 0.0, 100.0);
@@ -109,12 +109,12 @@ void wifi_off()
     WiFi.disconnect(true);
 }
 
-bool get_button_c_pressed(int button=13)
+bool ButtonCIsPressed(int button_pin_number=13)
 {
-    pinMode(button, PULLUP);
+    pinMode(button_pin_number, PULLUP);
     delay(50);
 
-    int pressed = digitalRead(button);
+    int pressed = digitalRead(button_pin_number);
     
     Serial.println("Button pressed!!!");
     Serial.printf("Button int: %d \n", pressed);
@@ -124,11 +124,11 @@ bool get_button_c_pressed(int button=13)
 
 void BeginSleep()
 {
-    // Function for deep sleep power savings - not implimented yet.
-    long SleepDuration = 60;                               // Sleep time in seconds, aligned to the nearest minute boundary, so if 30 will always update at 00 or 30 past the hour
-                                                           // int  WakeupTime    = 7;  // Don't wakeup until after 07:00 to save battery power
-                                                           // int  SleepTime     = 23; // Sleep after (23+1) 00:00 to save battery power
-    long SleepTimer = (SleepDuration);                     //Some ESP32 are too fast to maintain accurate time
+    // Function for deep sleep power savings
+    long SleepDuration = 60;  // Sleep time in seconds, aligned to the nearest minute boundary, so if 30 will always update at 00 or 30 past the hour
+    // int  WakeupTime    = 7;  // Don't wakeup until after 07:00 to save battery power
+    // int  SleepTime     = 23; // Sleep after (23+1) 00:00 to save battery power
+    long SleepTimer = (SleepDuration);  //Some ESP32 are too fast to maintain accurate time
     esp_sleep_enable_timer_wakeup((SleepTimer)*1000000LL); // Added +20 seconnds to cover ESP32 RTC timer source inaccuracies
 
     Serial.println("Entering " + String(SleepTimer) + "-secs of sleep time");
@@ -137,7 +137,8 @@ void BeginSleep()
     esp_deep_sleep_start(); // Sleep for e.g. 30 minutes
 }
 
-void testBLE()
+// Start the bluetooth system to update the wifi creds or bus stop number.
+void runBLE()
 {
     Serial.println("testing ble system");
     BLEDevice::init("esp32");
@@ -145,36 +146,37 @@ void testBLE()
     ble.startServer();
     delay(200);
     
-    while(!get_button_c_pressed()){
+    while(!ButtonCIsPressed()){
         delay(40);
     }
 }
 
 // Create display handle and display the predictions
-void write_predictions_to_display(PredictionPack prediction_pack)
+void writePredictionsToDisplay(PredictionPack prediction_pack)
 {
     DisplayHandle mbta_display = DisplayHandle(&display, &timeinfo);
 
     mbta_display.PrepDisplay();
 
-    float batt = get_battery_percentage();
+    float batt = getBatteryPercentage();
     mbta_display.WriteBanner(batt);
 
     mbta_display.writePredictions(prediction_pack.predictions, prediction_pack.num_predictions);
     mbta_display.displayData();
 }
 
-void run_bluetooth_mode()
+// Display the bluetooth screen, and turn on BLE.
+void runBluetoothMode()
 {
     Serial.println("engaging BT display");
     auto disp = DisplayHandle(&display, &timeinfo);
     disp.PrepDisplay();
-    float batt = get_battery_percentage();
+    float batt = getBatteryPercentage();
     disp.WriteBanner(batt);
     disp.writeBleScreen();
     disp.displayData();
     delay(2000);
-    testBLE();
+    runBLE();
 
 }
 
@@ -194,10 +196,10 @@ void setup()
     //wifistore.storeCredentials(networkName, networkPswd);
     //wifistore.storeStop(2579);
 
-    bool button_c = get_button_c_pressed();
+    bool button_c = ButtonCIsPressed();
     if (button_c)
     {
-        run_bluetooth_mode();
+        runBluetoothMode();
     }
 
     auto creds = wifistore.getCredentials();
@@ -212,7 +214,7 @@ void setup()
     
     auto prediction_pack = mbta.getPredictions(creds.mbtaStop);
 
-    write_predictions_to_display(prediction_pack);
+    writePredictionsToDisplay(prediction_pack);
 
     wifi_off();
     BeginSleep();

--- a/src/wifi_storage.hpp
+++ b/src/wifi_storage.hpp
@@ -4,6 +4,7 @@
 struct wifiCreds {
     char ssid[20];
     char pass[20];
+    int mbtaStop;
 };
 
 class WifiCredentialStore {
@@ -11,7 +12,9 @@ private:
     const char* storageNamespace = "wifiCreds";
     const char* ssidKey = "ssid";
     const char* passwdKey = "passwd";
+    const char* mbtaStopKey = "mbtaStop";
     Preferences flashStorage;
+
 public:
     void storeCredentials(const char* ssid, const char* password) {
         Serial.printf("storing wifi credentials: %s, %s \n", ssid, password);
@@ -35,12 +38,20 @@ public:
         flashStorage.end();
     }
 
+    void storeStop(int stopNumber)
+    {
+        flashStorage.begin(storageNamespace);
+        flashStorage.putInt(mbtaStopKey, stopNumber);
+        flashStorage.end();
+    }
+
     wifiCreds getCredentials() {
         wifiCreds credentials;
 
         flashStorage.begin(storageNamespace);
         auto ssidLength = flashStorage.getString(ssidKey, credentials.ssid, 20);
         auto passLength = flashStorage.getString(passwdKey, credentials.pass, 20);
+        credentials.mbtaStop = flashStorage.getInt(mbtaStopKey);
 
         Serial.printf("Got creds: %s, %s, lens: %d, %d  \n", credentials.ssid, credentials.pass, ssidLength, passLength);
         flashStorage.end();


### PR DESCRIPTION
## Changes

- Activate bluetooth mode by holding the "c" button down during reset, enabling BLE to change wifi/stop settings
- Add the mbta stop number to the wifi settings, allowing it to be changed without a firmware update
- Increase size of the JsonDocument to handle larger prediction data with different stops
- Clean up function naming format to use camelCase